### PR TITLE
切换音频为MP3格式并优化管理

### DIFF
--- a/EchoTrail Shared/GameAudio.swift
+++ b/EchoTrail Shared/GameAudio.swift
@@ -10,18 +10,23 @@ import AVFoundation
 final class GameAudio {
     static let shared = GameAudio()
 
+    enum Music: String {
+        case menu = "bg_menu_loop.mp3"
+        case game = "bg_game_loop.mp3"
+    }
+
     private var musicPlayer: AVAudioPlayer?
     private var fadingPlayer: AVAudioPlayer?
     private var link: CADisplayLink?
     private var startTime: CFTimeInterval = 0
     private var fadeDur: CFTimeInterval = 0.45
-    private var targetName: String = ""
+    private var currentTrack: Music?
 
     private init() { }
 
     // 对外接口
-    func playMenu() { crossfade(to: "bg_menu_loop.caf") }
-    func playGame() { crossfade(to: "bg_game_loop.caf") }
+    func playMenu() { crossfade(to: .menu) }
+    func playGame() { crossfade(to: .game) }
     func stopMusic() {
         musicPlayer?.stop()
         musicPlayer = nil
@@ -32,9 +37,10 @@ final class GameAudio {
     }
 
     // 交叉淡入淡出
-    private func crossfade(to file: String) {
-        guard targetName != file else { return } // 同曲则不切
-        targetName = file
+    private func crossfade(to track: Music) {
+        guard currentTrack != track else { return } // 同曲则不切
+        currentTrack = track
+        let file = track.rawValue
         let next = makePlayer(file)
         next?.volume = 0
         next?.numberOfLoops = -1

--- a/EchoTrail Shared/GameScene.swift
+++ b/EchoTrail Shared/GameScene.swift
@@ -21,13 +21,13 @@ final class GameScene: SKScene {
     let KINETIC_PERIOD = 5
     
     // 音频清单
-    struct AudioBank {
-        static let eatWhite = "sfx_eat_white.wav"
-        static let eatGold  = "sfx_eat_gold.wav"
-        static let echoSpawn = "sfx_echo_spawn.wav"
-        static let echoFuse  = "sfx_echo_fuse.wav"
-        static let bumpWall  = "sfx_bump_wall.wav"
-        static let gameOver  = "sfx_game_over.wav"
+    enum SFX: String {
+        case eatWhite = "sfx_eat_white.mp3"
+        case eatGold  = "sfx_eat_gold.mp3"
+        case echoSpawn = "sfx_echo_spawn.mp3"
+        case echoFuse  = "sfx_echo_fuse.mp3"
+        case bumpWall  = "sfx_bump_wall.mp3"
+        case gameOver  = "sfx_game_over.mp3"
     }
 
     // 状态
@@ -100,9 +100,10 @@ final class GameScene: SKScene {
         }
     }
 
-    func playSFXIfAvailable(_ filename: String) {
-        guard audioFileExists(filename) else { return }
-        run(.playSoundFileNamed(filename, waitForCompletion: false))
+    func playSFXIfAvailable(_ sfx: SFX) {
+        let file = sfx.rawValue
+        guard audioFileExists(file) else { return }
+        run(.playSoundFileNamed(file, waitForCompletion: false))
     }
 
     // 生命周期
@@ -215,7 +216,7 @@ final class GameScene: SKScene {
             return true
         } else {
             if isPlayer && dir != "W" && (t - lastBumpTick) > 5 {
-                playSFXIfAvailable(AudioBank.bumpWall)
+                playSFXIfAvailable(.bumpWall)
                 #if os(iOS)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 #endif
@@ -229,7 +230,7 @@ final class GameScene: SKScene {
         if balls[p] == .white {
             balls[p] = .gold
             refreshBallNode(at: p)
-            playSFXIfAvailable(AudioBank.eatWhite)
+            playSFXIfAvailable(.eatWhite)
         }
     }
 
@@ -239,7 +240,7 @@ final class GameScene: SKScene {
         switch tball {
         case .white:
             score += 10
-            playSFXIfAvailable(AudioBank.eatWhite)
+            playSFXIfAvailable(.eatWhite)
             spawnParticle(at: p, color: .white)
             #if os(iOS)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -248,7 +249,7 @@ final class GameScene: SKScene {
             score += Int(30 * multiplier.rounded(.towardZero))
             multiplier = min(multiplier + 0.5, 4.0)
             multExpire = t + 50
-            playSFXIfAvailable(AudioBank.eatGold)
+            playSFXIfAvailable(.eatGold)
             spawnParticle(at: p, color: SKColor(red: 0.98, green: 0.75, blue: 0.14, alpha: 1))
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -284,7 +285,7 @@ final class GameScene: SKScene {
                 }
             }
             score += 50; multiplier = min(multiplier + 0.5, 4.0); multExpire = t + 50
-            playSFXIfAvailable(AudioBank.echoFuse)
+            playSFXIfAvailable(.echoFuse)
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             #endif
@@ -309,7 +310,7 @@ final class GameScene: SKScene {
         world.addChild(e.node)
         echoes.append(e)
         epeak = max(epeak, echoes.count)
-        playSFXIfAvailable(AudioBank.echoSpawn)
+        playSFXIfAvailable(.echoSpawn)
         #if os(iOS)
         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
         #endif
@@ -339,7 +340,7 @@ final class GameScene: SKScene {
 
     func gameOver(_ reason: String) {
         state = .over
-        playSFXIfAvailable(AudioBank.gameOver)
+        playSFXIfAvailable(.gameOver)
         GameAudio.shared.stopMusic()
         #if os(iOS)
         UINotificationFeedbackGenerator().notificationOccurred(.error)


### PR DESCRIPTION
## Summary
- 使用枚举统一管理音乐与音效资源
- 更换所有音频文件为 MP3 并相应调整调用逻辑

## Testing
- `npm --version >/dev/null 2>&1 && npx eslint --fix . || echo 'eslint not run'`
- `npx stylelint "**/*.{css,scss,vue,html}" --fix || echo 'stylelint not run'`
- `npx prettier -w . || echo 'prettier not run'`
- `mvn spotless:apply || echo 'mvn not run'`


------
https://chatgpt.com/codex/tasks/task_e_68a3606b143c8332952c50dc4a60fd23