### PR TITLE
feat: unify input handling via controllers

### DIFF
--- a/EchoTrail Shared/InputController.swift
+++ b/EchoTrail Shared/InputController.swift
@@ -1,0 +1,15 @@
+import SpriteKit
+
+protocol InputController: AnyObject {
+    var currentDirection: String? { get }
+    var isWaiting: Bool { get }
+    var onStart: (() -> Void)? { get set }
+#if os(iOS)
+    func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene)
+    func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene)
+    func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene)
+#elseif os(macOS)
+    func keyDown(_ event: NSEvent, in scene: GameScene)
+    func keyUp(_ event: NSEvent, in scene: GameScene)
+#endif
+}

--- a/EchoTrail Shared/KeyboardInputController.swift
+++ b/EchoTrail Shared/KeyboardInputController.swift
@@ -1,0 +1,27 @@
+#if os(macOS)
+import SpriteKit
+
+final class KeyboardInputController: InputController {
+    weak var scene: GameScene?
+    var currentDirection: String?
+    var isWaiting: Bool = false
+    var onStart: (() -> Void)?
+
+    init(scene: GameScene) {
+        self.scene = scene
+    }
+
+    func keyDown(_ event: NSEvent, in scene: GameScene) {
+        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
+        if let dir = map[event.keyCode] { currentDirection = dir }
+        if event.charactersIgnoringModifiers == " " { isWaiting = true }
+        onStart?()
+    }
+
+    func keyUp(_ event: NSEvent, in scene: GameScene) {
+        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
+        if map[event.keyCode] != nil { currentDirection = nil }
+        if event.charactersIgnoringModifiers == " " { isWaiting = false }
+    }
+}
+#endif

--- a/EchoTrail Shared/TouchInputController.swift
+++ b/EchoTrail Shared/TouchInputController.swift
@@ -1,0 +1,61 @@
+#if os(iOS)
+import SpriteKit
+
+final class TouchInputController: InputController {
+    weak var scene: GameScene?
+    var currentDirection: String?
+    var isWaiting: Bool = false
+    var onStart: (() -> Void)?
+
+    private var joyActive = false
+    private var joyOrigin = CGPoint.zero
+
+    init(scene: GameScene) {
+        self.scene = scene
+    }
+
+    func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene) {
+        guard let t = touches.first else { return }
+        joyOrigin = t.location(in: scene)
+        scene.joyBg.position = joyOrigin
+        scene.joyKnob.position = joyOrigin
+        scene.joyBg.isHidden = false
+        scene.joyKnob.isHidden = false
+        joyActive = true
+        isWaiting = false
+        onStart?()
+    }
+
+    func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene) {
+        guard joyActive, let t = touches.first else { return }
+        let p = t.location(in: scene)
+        let dx = p.x - joyOrigin.x
+        let dy = p.y - joyOrigin.y
+        let dist = hypot(dx, dy)
+        let ang = atan2(dy, dx)
+        let maxR: CGFloat = 50
+        let r = min(maxR, dist)
+        scene.joyKnob.position = CGPoint(x: joyOrigin.x + cos(ang) * r, y: joyOrigin.y + sin(ang) * r)
+        let dead: CGFloat = 14
+        if dist < dead {
+            currentDirection = nil
+            isWaiting = true
+            return
+        }
+        isWaiting = false
+        if abs(dx) > abs(dy) {
+            currentDirection = dx > 0 ? "R" : "L"
+        } else {
+            currentDirection = dy > 0 ? "U" : "D"
+        }
+    }
+
+    func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?, in scene: GameScene) {
+        joyActive = false
+        scene.joyBg.isHidden = true
+        scene.joyKnob.isHidden = true
+        currentDirection = nil
+        isWaiting = false
+    }
+}
+#endif

--- a/EchoTrail iOS/GameViewController.swift
+++ b/EchoTrail iOS/GameViewController.swift
@@ -19,6 +19,8 @@ class GameViewController: UIViewController {
         skView.ignoresSiblingOrder = true
 
         let scene = GameScene(size: skView.bounds.size)
+        let controller = TouchInputController(scene: scene)
+        scene.input = controller
         scene.scaleMode = .resizeFill
         skView.presentScene(scene)
     }

--- a/EchoTrail macOS/GameViewController.swift
+++ b/EchoTrail macOS/GameViewController.swift
@@ -19,6 +19,8 @@ class GameViewController: NSViewController {
         skView.ignoresSiblingOrder = true
 
         let scene = GameScene(size: skView.bounds.size)
+        let controller = KeyboardInputController(scene: scene)
+        scene.input = controller
         scene.scaleMode = .resizeFill
         skView.presentScene(scene)
 


### PR DESCRIPTION
## Summary
- define cross-platform `InputController` protocol
- implement iOS `TouchInputController` and macOS `KeyboardInputController`
- refactor `GameScene` and view controllers to use unified input

## Testing
- `npx eslint --fix .` *(fails: ESLint couldn't find config)*
- `npx stylelint "**/*.{css,scss}" --fix` *(fails: npm error canceled)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_68a35e317c98833280bc7019def6d867