### PR TITLE
Fix joystick orientation and clear game-over overlay

### DIFF
--- a/EchoTrail Shared/GameOverOverlay.swift
+++ b/EchoTrail Shared/GameOverOverlay.swift
@@ -1,0 +1,40 @@
+import SpriteKit
+
+/// “游戏结束”覆盖层，含背景与文本
+final class GameOverOverlay: SKNode {
+    private let background: SKShapeNode
+    private let label: SKLabelNode
+    private let padding: CGFloat = 20
+    private let corner: CGFloat = 16
+
+    override init() {
+        background = SKShapeNode()
+        label = SKLabelNode(fontNamed: "Menlo-Bold")
+        super.init()
+        label.fontSize = 14
+        label.fontColor = .white
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        addChild(background)
+        addChild(label)
+        zPosition = 2000
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func show(message: String, in scene: SKScene) {
+        label.text = message
+        let width = label.frame.width + padding * 2
+        let height = label.frame.height + padding * 2
+        let rect = CGRect(x: -width / 2, y: -height / 2, width: width, height: height)
+        background.path = CGPath(roundedRect: rect, cornerWidth: corner, cornerHeight: corner, transform: nil)
+        background.fillColor = Theme.accent.withAlphaComponent(0.2)
+        background.strokeColor = Theme.accent.withAlphaComponent(0.4)
+        background.lineWidth = 2
+        background.glowWidth = 4
+        position = CGPoint(x: scene.size.width / 2, y: scene.size.height / 2)
+        if parent == nil { scene.addChild(self) }
+    }
+
+    func hide() { removeFromParent() }
+}

--- a/EchoTrail Shared/GameScene.swift
+++ b/EchoTrail Shared/GameScene.swift
@@ -66,6 +66,7 @@ final class GameScene: SKScene {
     let world = SKNode()
     let hud = SKNode()
     var hudManager: HUDManager!
+    private let gameOverOverlay = GameOverOverlay()
 
     // 虚拟摇杆（iOS 使用）
     let joystick = JoystickView()
@@ -120,6 +121,7 @@ final class GameScene: SKScene {
 
     // 地图与实体
     func buildMap() {
+        gameOverOverlay.hide()
         world.removeAllChildren()
         echoes.removeAll()
         obstKinetic.removeAll()
@@ -206,7 +208,7 @@ final class GameScene: SKScene {
     func pushTail(_ e: inout Entity) { e.tail.insert(e.pos, at: 0); if e.tail.count > 6 { _ = e.tail.popLast() } }
 
     func tryMove(_ e: inout Entity, dir: String, isPlayer: Bool) -> Bool {
-        let dmap: [String:(Int,Int)] = ["U":(0,-1),"D":(0,1),"L":(-1,0),"R":(1,0),"W":(0,0)]
+        let dmap: [String:(Int,Int)] = ["U":(0,1),"D":(0,-1),"L":(-1,0),"R":(1,0),"W":(0,0)]
         let d = dmap[dir] ?? (0,0)
         let np = IntPoint(x: e.pos.x + d.0, y: e.pos.y + d.1)
         e.prev = e.pos
@@ -345,9 +347,8 @@ final class GameScene: SKScene {
         #if os(iOS)
         UINotificationFeedbackGenerator().notificationOccurred(.error)
         #endif
-        let label = SKLabelNode(text: "游戏结束：\(reason)  分数 \(score)  生存 \(String(format: "%.1f", timeSec)) 秒  峰值回声 \(epeak)")
-        label.fontName = "Menlo-Bold"; label.fontSize = 14; label.position = CGPoint(x: size.width/2, y: size.height/2)
-        addChild(label)
+        let message = "游戏结束：\(reason)\n分数 \(score)  生存 \(String(format: "%.1f", timeSec)) 秒\n峰值回声 \(epeak)"
+        gameOverOverlay.show(message: message, in: self)
     }
 
     // 主更新


### PR DESCRIPTION
## Summary
- correct joystick direction mapping
- add reusable game-over overlay and clear it when restarting

## Testing
- `npx eslint --fix .`
- `npx stylelint --fix "**/*.{css,scss}"`
- `npx prettier -w .`
- `mvn spotless:apply`


------
https://chatgpt.com/codex/tasks/task_e_68a362f3ca308332babf790aacaede52