### PR TITLE
修复 GameOverOverlay 未被编译的问题

### DIFF
--- a/EchoTrail.xcodeproj/project.pbxproj
+++ b/EchoTrail.xcodeproj/project.pbxproj
@@ -22,14 +22,15 @@
 			membershipExceptions = (
 				Actions.sks,
 				Assets.xcassets,
-				GameAudio.swift,
+                                GameAudio.swift,
                                 GameScene.sks,
                                 GameScene.swift,
+                                GameOverOverlay.swift,
                                 IntPoint.swift,
                                 HUDManager.swift,
                                 JoystickView.swift,
                                 Theme.swift,
-			);
+                        );
 			target = E1059B222E5384090024A1F7 /* EchoTrail iOS */;
 		};
 		E1059B4A2E5384090024A1F7 /* Exceptions for "EchoTrail Shared" folder in "EchoTrail macOS" target */ = {
@@ -37,14 +38,15 @@
 			membershipExceptions = (
 				Actions.sks,
 				Assets.xcassets,
-				GameAudio.swift,
+                                GameAudio.swift,
                                 GameScene.sks,
                                 GameScene.swift,
+                                GameOverOverlay.swift,
                                 IntPoint.swift,
                                 HUDManager.swift,
                                 JoystickView.swift,
                                 Theme.swift,
-			);
+                        );
 			target = E1059B332E5384090024A1F7 /* EchoTrail macOS */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */


### PR DESCRIPTION
## 摘要
- 将 GameOverOverlay.swift 加入 iOS 与 macOS 目标的同步例外列表，确保覆盖层参与编译

## 测试
- `npx eslint --fix`（缺少 eslint.config.js）
- `npx stylelint "**/*.{css,scss,vue}" --fix`（未找到匹配文件）
- `npx prettier -w .`
- `mvn spotless:apply`（缺少插件或网络不可达）

------
https://chatgpt.com/codex/tasks/task_e_68a366e8bb34833296afe6d836007d1d