### PR TITLE
重构输入控制为触控与键盘控制器

### DIFF
--- a/EchoTrail Shared/GameScene.swift
+++ b/EchoTrail Shared/GameScene.swift
@@ -56,10 +56,9 @@ final class GameScene: SKScene {
     let hud = SKNode()
     var hudManager: HUDManager!
     private let gameOverOverlay = GameOverOverlay()
+    var inputController: InputControllerProtocol!
 
     // 虚拟摇杆（iOS 使用）
-    let joystick = JoystickView()
-    var joyActive = false
 
     // 驱动
     var lastUpdate: TimeInterval = 0
@@ -86,7 +85,13 @@ final class GameScene: SKScene {
         addChild(hud)
         hudManager = HUDManager(sceneSize: size)
         hud.addChild(hudManager)
-        hud.addChild(joystick)
+        #if os(iOS)
+        inputController = TouchInputController()
+        #elseif os(macOS)
+        inputController = KeyboardInputController()
+        #endif
+        inputController.delegate = self
+        inputController.configure(scene: self)
         buildMap()
         enterIdle()
     }
@@ -408,42 +413,19 @@ final class GameScene: SKScene {
     func enterIdle() { state = .idle; GameAudio.shared.stopMusic(); GameAudio.shared.playMenu() }
     func enterPlaying() { state = .playing; GameAudio.shared.stopMusic(); GameAudio.shared.playGame() }
 
-    // 触控（iOS）
-    #if os(iOS)
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let t = touches.first else { return }
-        joystick.activate(at: t.location(in: self), in: size)
-        joyActive = true
-        waitingHold = false
-        if state == .idle || state == .over { buildMap(); enterPlaying() }
-    }
-    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard joyActive, let t = touches.first else { return }
-        let vec = joystick.update(to: t.location(in: self))
-        let dx = vec.dx, dy = vec.dy
-        let dist = hypot(dx, dy)
-        let dead: CGFloat = 0.14
-        if dist < dead { continuousDir = nil; waitingHold = true; return }
-        waitingHold = false
-        if abs(dx) > abs(dy) { continuousDir = dx > 0 ? "R" : "L" } else { continuousDir = dy > 0 ? "U" : "D" }
-    }
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        joystick.deactivate(); joyActive = false; continuousDir = nil; waitingHold = false
-    }
-    #endif
 
-    // 键盘（macOS 或外接键盘）
-    #if os(macOS)
-    override func keyDown(with event: NSEvent) {
-        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
-        if let dir = map[event.keyCode] { continuousDir = dir }
-        if event.charactersIgnoringModifiers == " " { waitingHold = true }
+}
+
+extension GameScene: InputControllerDelegate {
+    func directionChanged(to direction: String?) {
+        continuousDir = direction
+    }
+
+    func holdChanged(isHolding: Bool) {
+        waitingHold = isHolding
+    }
+
+    func startRequested() {
         if state == .idle || state == .over { buildMap(); enterPlaying() }
     }
-    override func keyUp(with event: NSEvent) {
-        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
-        if map[event.keyCode] != nil { continuousDir = nil }
-        if event.charactersIgnoringModifiers == " " { waitingHold = false }
-    }
-    #endif
 }

--- a/EchoTrail Shared/Input/InputControllerProtocol.swift
+++ b/EchoTrail Shared/Input/InputControllerProtocol.swift
@@ -1,0 +1,12 @@
+import SpriteKit
+
+protocol InputControllerDelegate: AnyObject {
+    func directionChanged(to direction: String?)
+    func holdChanged(isHolding: Bool)
+    func startRequested()
+}
+
+protocol InputControllerProtocol: AnyObject {
+    var delegate: InputControllerDelegate? { get set }
+    func configure(scene: GameScene)
+}

--- a/EchoTrail Shared/Input/KeyboardInputController.swift
+++ b/EchoTrail Shared/Input/KeyboardInputController.swift
@@ -1,0 +1,39 @@
+#if os(macOS)
+import SpriteKit
+
+final class KeyboardInputController: InputControllerProtocol {
+    weak var delegate: InputControllerDelegate?
+
+    func configure(scene: GameScene) {}
+
+    func keyDown(with event: NSEvent) {
+        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
+        if let dir = map[event.keyCode] {
+            delegate?.directionChanged(to: dir)
+        }
+        if event.charactersIgnoringModifiers == " " {
+            delegate?.holdChanged(isHolding: true)
+        }
+        delegate?.startRequested()
+    }
+
+    func keyUp(with event: NSEvent) {
+        let map: [UInt16:String] = [126:"U",125:"D",123:"L",124:"R"]
+        if map[event.keyCode] != nil {
+            delegate?.directionChanged(to: nil)
+        }
+        if event.charactersIgnoringModifiers == " " {
+            delegate?.holdChanged(isHolding: false)
+        }
+    }
+}
+
+extension GameScene {
+    override func keyDown(with event: NSEvent) {
+        (inputController as? KeyboardInputController)?.keyDown(with: event)
+    }
+    override func keyUp(with event: NSEvent) {
+        (inputController as? KeyboardInputController)?.keyUp(with: event)
+    }
+}
+#endif

--- a/EchoTrail Shared/Input/TouchInputController.swift
+++ b/EchoTrail Shared/Input/TouchInputController.swift
@@ -1,0 +1,62 @@
+#if os(iOS)
+import SpriteKit
+import UIKit
+
+final class TouchInputController: InputControllerProtocol {
+    weak var delegate: InputControllerDelegate?
+    private let joystick = JoystickView()
+    private var joyActive = false
+    private weak var scene: GameScene?
+
+    func configure(scene: GameScene) {
+        self.scene = scene
+        scene.hud.addChild(joystick)
+    }
+
+    func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let scene = scene, let t = touches.first else { return }
+        joystick.activate(at: t.location(in: scene), in: scene.size)
+        joyActive = true
+        delegate?.holdChanged(isHolding: false)
+        delegate?.startRequested()
+    }
+
+    func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard joyActive, let scene = scene, let t = touches.first else { return }
+        let vec = joystick.update(to: t.location(in: scene))
+        let dx = vec.dx, dy = vec.dy
+        let dist = hypot(dx, dy)
+        let dead: CGFloat = 0.14
+        if dist < dead {
+            delegate?.directionChanged(to: nil)
+            delegate?.holdChanged(isHolding: true)
+            return
+        }
+        delegate?.holdChanged(isHolding: false)
+        if abs(dx) > abs(dy) {
+            delegate?.directionChanged(to: dx > 0 ? "R" : "L")
+        } else {
+            delegate?.directionChanged(to: dy > 0 ? "U" : "D")
+        }
+    }
+
+    func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        joystick.deactivate()
+        joyActive = false
+        delegate?.directionChanged(to: nil)
+        delegate?.holdChanged(isHolding: false)
+    }
+}
+
+extension GameScene {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        (inputController as? TouchInputController)?.touchesBegan(touches, with: event)
+    }
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        (inputController as? TouchInputController)?.touchesMoved(touches, with: event)
+    }
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        (inputController as? TouchInputController)?.touchesEnded(touches, with: event)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- 抽象输入协议并实现 iOS 触控与 macOS 键盘控制器
- GameScene 通过 InputControllerProtocol 统一接入并移除平台条件输入逻辑

## Testing
- `npx eslint --fix .` *(fails: ESLint couldn't find configuration)*
- `npx stylelint "**/*.{css,scss}" --fix` *(fails: npm error canceled)*
- `npx prettier -w .`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*


------
https://chatgpt.com/codex/tasks/task_e_68a368cc7a388332a3ecb99c79cf4c90