### PR TITLE
添加 Xcode 项目的通用 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# ===== macOS =====
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# ===== Xcode =====
+DerivedData/
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+# ===== Swift Package Manager =====
+.build/
+Packages/
+Package.resolved
+
+# ===== CocoaPods =====
+Pods/
+
+# ===== Carthage =====
+Carthage/Build/
+
+# ===== Accio =====
+Dependencies/
+
+# ===== fastlane =====
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# ===== Code Coverage =====
+*.xccoverage
+
+# ===== Other =====
+*.ipa
+*.dSYM.zip
+*.dSYM


### PR DESCRIPTION
## 摘要
- 为 iOS/macOS 工程建立标准化的 `.gitignore`

## 测试
- `eslint --fix`（缺少配置文件）
- `stylelint --fix`（命令不存在）
- `prettier -w .gitignore`（无法推断解析器）
- `mvn spotless:apply`（无法解析依赖）

------
https://chatgpt.com/codex/tasks/task_e_68a3686ae4dc83328b2eec1b06c1fb03