### PR TITLE
Include shared modules in Xcode targets

### DIFF
--- a/EchoTrail.xcodeproj/project.pbxproj
+++ b/EchoTrail.xcodeproj/project.pbxproj
@@ -20,35 +20,45 @@
 		E1059B462E5384090024A1F7 /* Exceptions for "EchoTrail Shared" folder in "EchoTrail iOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Actions.sks,
-				Assets.xcassets,
-				GameAudio.swift,
-				GameOverOverlay.swift,
-				GameScene.sks,
-				GameScene.swift,
-				HUDManager.swift,
-				IntPoint.swift,
-				JoystickView.swift,
-				Theme.swift,
-			);
-			target = E1059B222E5384090024A1F7 /* EchoTrail iOS */;
-		};
-		E1059B4A2E5384090024A1F7 /* Exceptions for "EchoTrail Shared" folder in "EchoTrail macOS" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Actions.sks,
-				Assets.xcassets,
-				GameAudio.swift,
-				GameOverOverlay.swift,
-				GameScene.sks,
-				GameScene.swift,
-				HUDManager.swift,
-				IntPoint.swift,
-				JoystickView.swift,
-				Theme.swift,
-			);
-			target = E1059B332E5384090024A1F7 /* EchoTrail macOS */;
-		};
+                                Actions.sks,
+                                Assets.xcassets,
+                                Audio,
+                                Config,
+                                Core,
+                                Entity.swift,
+                                GameAudio.swift,
+                                GameOverOverlay.swift,
+                                GameScene.sks,
+                                GameScene.swift,
+                                HUDManager.swift,
+                                Input,
+                                IntPoint.swift,
+                                JoystickView.swift,
+                                Theme.swift,
+                        );
+                        target = E1059B222E5384090024A1F7 /* EchoTrail iOS */;
+                };
+                E1059B4A2E5384090024A1F7 /* Exceptions for "EchoTrail Shared" folder in "EchoTrail macOS" target */ = {
+                        isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+                        membershipExceptions = (
+                                Actions.sks,
+                                Assets.xcassets,
+                                Audio,
+                                Config,
+                                Core,
+                                Entity.swift,
+                                GameAudio.swift,
+                                GameOverOverlay.swift,
+                                GameScene.sks,
+                                GameScene.swift,
+                                HUDManager.swift,
+                                Input,
+                                IntPoint.swift,
+                                JoystickView.swift,
+                                Theme.swift,
+                        );
+                        target = E1059B332E5384090024A1F7 /* EchoTrail macOS */;
+                };
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */


### PR DESCRIPTION
## Summary
- include shared Config, Core, Input, and Entity sources in both iOS and macOS targets

## Testing
- `npx --yes eslint --fix .` *(fails: ESLint couldn't find an eslint.config)*
- `npx --yes stylelint "**/*.{css,scss}" --fix` *(fails: No files matching the pattern "**/*.{css,scss}" were found)*
- `npx --yes prettier -w .`
- `mvn spotless:apply` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_68a377f5f7bc83328cd7c92173c984fe